### PR TITLE
TM1638 in Common Anode mode, 10 Digits, 8 Segment [TM1638Anode.h]

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Added library functionality:
 - Simple display of text and numbers on 7-segment displays using familiar print() and println() methods.
 - Support for the Adafruit GFX graphics library for advanced graphics on a LED matrix.
 - Full support for QYF-TM1638 module (8 digit common anode LED display and 4x4 keypad)
+- Support for TM1638 in Annode Mode (10 digit common anode LED 8 segment display) [TM1638Anode.h]
 - Support for combining multiple modules into one large Adafruit GFX matrix.
 - Support for scanning all possible keys (K1, K2 and K3 lines) on TM1638.
 - Support for release, click, doubleclick and long press button detection using callback functions.

--- a/examples/TM1638_Anode_two_modules_Display_Print/TM1638_Anode_two_modules_Display_Print.ino
+++ b/examples/TM1638_Anode_two_modules_Display_Print/TM1638_Anode_two_modules_Display_Print.ino
@@ -1,0 +1,38 @@
+/*
+  Basic library example for 2 X TM1638 Common Anode up to 10 digit, 8 segment. 
+  Kept small to show the simplest display functionality.
+  Library based on TM1638 library by Ricardo Batista, adapted by Maxint-RD MMOLE 2018.
+  
+  Tested to work:
+      ESP32 using Arduino IDE 1.8.13
+  For more information see  https://github.com/maxint-rd/TM16xx
+  Schemathics of Anode connection available here https://github.com/SkullKill/ESP32-Wall-Clock-PCB and https://github.com/SkullKill/ESP32-Wall-Clock-PCB/wiki
+
+*/
+
+#include <TM1638Anode.h>
+#include <TM16xxDisplay.h>
+
+//TM1638Anode module1(25, 26, 27, true, 7); // DIO=8, CLK=9, STB=7, activateDisplay, intensity
+TM1638Anode module1(25, 26, 27);
+TM16xxDisplay display1(&module1, 6);    // TM16xx object, 8 digits
+
+//TM1638Anode module2(25, 26, 21, true, 1); // DIO=8, CLK=9, STB=7, activateDisplay, intensity
+TM1638Anode module2(25, 26, 21);
+TM16xxDisplay display2(&module2, 10);    // TM16xx object, 8 digits
+
+
+
+void setup() {
+//  display.println(F("HELLO !"));
+  display1.println("12.34.5.6");
+  display2.println("123456.7895");
+  display2.setIntensity(2);
+}
+
+int nCount=0;
+void loop() {
+  delay(1000);
+  display2.println((String)"Count:" + nCount);
+  nCount++;
+}

--- a/src/TM1638Anode.cpp
+++ b/src/TM1638Anode.cpp
@@ -1,0 +1,95 @@
+/*
+TM1638Anode.cpp - Library implementation for TM1638 with Common Anode up to 10 digits.
+
+Made by Maxint R&D, based on TM1638 class. See https://github.com/maxint-rd/
+Modified by Simon Kong Win Chang (SkullKill) https://github.com/skullkill
+Schemathics of Anode connection available here https://github.com/SkullKill/ESP32-Wall-Clock-PCB and https://github.com/SkullKill/ESP32-Wall-Clock-PCB/wiki
+
+*/
+
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include "Arduino.h"
+#else
+	#include "WProgram.h"
+#endif
+
+#include "TM1638Anode.h"
+
+TM1638Anode::TM1638Anode(byte dataPin, byte clockPin, byte strobePin, boolean activateDisplay, byte intensity)
+	: TM16xx(dataPin, clockPin, strobePin, TM1638Anode_MAX_POS, 10, activateDisplay, intensity)
+{
+  _maxSegments=8;		// on the QYF-TM1638 modules the two extra segment lines are not used. The display uses common anode LEDs
+    //_numDigits = numDigits;
+	memset(this->bitmap, 0, TM1638Anode_MAX_POS);
+	clearDisplay();
+	setupDisplay(activateDisplay, intensity);
+}
+
+void TM1638Anode::setSegments(byte segments, byte position)
+{	// set 10 leds on common grd as specified
+    // TM1638 uses 10 segments in two bytes, similar to TM1668
+    // for the digit displays both byte (containing seg1-seg10) are sent
+	if(position<_maxDisplays)
+	{
+		//update our memory bitmap
+		this->bitmap[position]=segments;
+
+		// transpose the bitmap to counter Common Anode connections
+		for(byte nPos=0; nPos < _maxSegments; nPos++)
+		{
+			uint16_t btVal = 0;
+			for (byte j = 0; j < TM1638Anode_MAX_POS; j++)
+			{
+				// for schematics of inverted connection, 1st digit connected to SEG10, 2nd digit connected to SEG9 etc
+				//btVal |= ((pVal[j] >> nPos) & 1) << (TM1638Anode_MAX_POS - j - 1);
+				// for schematics of 1st digit connected to SEG1, 2nd digit connected to SEG2 etc
+				btVal |= ((this->bitmap[j] >> nPos) & 1) << (j);
+			}
+			// send each byte of the transposed bitmap
+			//send 1st byte of data
+			sendData(nPos << 1, (byte)btVal&0xFF);
+			// send 2nd byte of data
+			sendData((nPos << 1) | 1, (byte)(btVal>>8)&0x03);
+		}
+		
+	}
+}
+
+
+
+void TM1638Anode::clearDisplay()
+{
+  for(byte nPos=0; nPos<TM1638Anode_MAX_POS; nPos++)
+  {
+	  // all OFF
+	  sendData(nPos << 1, 0);
+	  sendData((nPos << 1) | 1, 0);
+	  // all ON
+	  //sendData(nPos << 1, 0b11111111);
+	  //sendData((nPos << 1) | 1, 0b00000011);
+  }
+}
+
+uint32_t TM1638Anode::getButtons(void)
+{
+	// TM1638 returns 4 bytes/8 nibbles for keyscan. Each byte has K3, K2 and K1 status in lower bits of each nibble for KS1-KS8
+	// NOTE: K3 is implemented for this class, but the TM1638Anode module only uses K1/K2
+  byte keys_K1 = 0;
+  byte keys_K2 = 0;
+  byte keys_K3 = 0;
+
+  start();
+  send(TM16XX_CMD_DATA_READ); // B01000010 Read the key scan data
+
+  for (int i = 0; i < 4; i++)
+  {
+	  byte rec = receive();
+    keys_K1 |= ((rec&_BV(2))>>2 | (rec&_BV(6))>>5) << (2*i);			// bits 2 and	6 for K1/KS1 and K1/KS2
+    keys_K2 |= ((rec&_BV(1))>>1 | (rec&_BV(5))>>4) << (2*i);			// bits 1 and	5 for K2/KS1 and K2/KS2
+    keys_K3 |= ((rec&_BV(0))    | (rec&_BV(4))>>3) << (2*i);			// bits 0 and	4 for K3/KS1 and K3/KS2
+  }
+
+  stop();
+
+  return((uint32_t)keys_K3<<16 | (uint32_t)keys_K2<<8 | (uint32_t)keys_K1);
+}

--- a/src/TM1638Anode.h
+++ b/src/TM1638Anode.h
@@ -1,0 +1,43 @@
+/*
+TM1638Anode.h - Library implementation for TM1638 with Common Anode up to 10 digits.
+
+Made by Maxint R&D, based on TM1638 class. See https://github.com/maxint-rd/
+Modified by Simon Kong Win Chang (SkullKill) https://github.com/skullkill
+Schemathics of Anode connection available here https://github.com/SkullKill/ESP32-Wall-Clock-PCB and https://github.com/SkullKill/ESP32-Wall-Clock-PCB/wiki
+
+*/
+
+#ifndef TM1638Anode_h
+#define TM1638Anode_h
+
+#if defined(ARDUINO) && ARDUINO >= 100
+	#include "Arduino.h"
+#else
+	#include "WProgram.h"
+#endif
+
+#include "TM16xx.h"
+
+#define TM1638Anode_MAX_POS 10
+
+class TM1638Anode : public TM16xx
+{
+  public:
+    /** Instantiate a tm1638 module specifying data, clock and stobe pins, the display state, the starting intensity (0-7). */
+    TM1638Anode(byte dataPin, byte clockPin, byte strobePin, boolean activateDisplay = true, byte intensity = 7);
+
+		/** Set the segments at a specific position on or off */
+	  virtual void setSegments(byte segments, byte position);
+
+		/** Clear the display */
+		virtual void clearDisplay();
+
+    /** Returns the pressed buttons as a bit set (left to right). */
+    virtual uint32_t getButtons();
+
+  private:
+		byte bitmap[TM1638Anode_MAX_POS];		// store a bitmap for all 8 digit to allow common anode manipulation
+		
+};
+
+#endif


### PR DESCRIPTION
TM1638 in Common Anode mode, 10 Digits, 8 Segment

for schematics of 1st digit connected to SEG1, 2nd digit connected to SEG2  of TM1638 etc....

Schemathics of Anode connection available here https://github.com/SkullKill/ESP32-Wall-Clock-PCB and https://github.com/SkullKill/ESP32-Wall-Clock-PCB/wiki


did not modify the TM1638QYF.h module because, it looks like this has an inverted connection for the digits , i.e 1st digit connected to SEG8, 2nd digit connected to SEG7 etc...

![ESP32-Wall-Clock-01](https://user-images.githubusercontent.com/20982257/91472382-f1249b00-e8c9-11ea-8b2a-c0d1e0052a7f.jpg)


![ESP32-Wall-Clock-schematics-03-V1 0](https://user-images.githubusercontent.com/20982257/91472359-e79b3300-e8c9-11ea-954f-9ba016cbac5b.jpg)
