### PR TITLE
Facilitate compilation for ESP32

### DIFF
--- a/src/TM1650.cpp
+++ b/src/TM1650.cpp
@@ -121,7 +121,7 @@ void TM1650::clearDisplay()
 void TM1650::setupDisplay(boolean active, byte intensity)
 {	// For the TM1650 level 0 is maximum brightness, 1-7 is low to high.
 	// To align with other TM16XX chips we translate this to the same levels (0-7)
-	intensity=min(7, intensity);
+	intensity=(7 & intensity);
 	intensity+=1;
 	if(intensity==8) intensity=0;
 	start();

--- a/src/TM16xx.cpp
+++ b/src/TM16xx.cpp
@@ -61,7 +61,7 @@ TM16xx::TM16xx(byte dataPin, byte clockPin, byte strobePin, byte maxDisplays, by
 
 void TM16xx::setupDisplay(boolean active, byte intensity)
 {
-  sendCommand(TM16XX_CMD_DISPLAY | (active ? 8 : 0) | min(7, intensity));
+  sendCommand(TM16XX_CMD_DISPLAY | (active ? 8 : 0) | (7 & intensity));
 }
 
 void TM16xx::clearDisplay()

--- a/src/TM16xx.h
+++ b/src/TM16xx.h
@@ -26,12 +26,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 	#include "WProgram.h"
 #endif
 
+/*
+// Removed to allow ESP32 compilation. Not needed for AVR as of 2021-09, tested compile w/ ESP32 and Uno
 #if !defined(max)
 // MMOLE 180325:
 // min, max are no macro in ESP core 2.3.9 libraries, see https://github.com/esp8266/Arduino/issues/398
 #define min(a,b) ((a)<(b)?(a):(b))
 #define max(a,b) ((a)>(b)?(a):(b))
 #endif
+*/
 
 #define TM16XX_CMD_DATA_AUTO 0x40
 #define TM16XX_CMD_DATA_READ 0x42			// command to read data used on two wire interfaces of TM1637


### PR DESCRIPTION
The ESP32 tool chain provides min() and max() functions. These can not be easily over ridden by redefinition of the macros because the redefinition code can not detect functions. Secondly, there are two non-mandatory uses of min() in the code, that can only be fixed by casting. As a cast for such a simple purpose seems gratuitous, they have been replaced by a simple bit mask operation. It's driver code that uses bit concatenation, so low level logic is not inappropriate.

This change removes the redefinition code, and alter all instances of min() to use bit masking instead. The result is that the library will compile with the current ESP32 core. It was also tested for the AVR, choosing the UNO board for compilation.

See: [https://github.com/esp8266/Arduino/issues/398#issuecomment-356034907](url)

This is a prerequisite for further changes that fix a different issue, crashes due to the use of system functions in a constructor.

Edit - I realized this doesn't have the same effect on brightness parameters. I have a better solution so I'm going to try to close this.