### PR TITLE
TM1650 read key command better compatibility with FD650B

### DIFF
--- a/src/TM1650.h
+++ b/src/TM1650.h
@@ -27,7 +27,7 @@ Partially based on TM1640 library by MRicardo Batista. See https://github.com/rj
 #define TM1650_DISPMODE_4x7 0x09
 
 #define TM1650_CMD_MODE  0x48
-#define TM1650_CMD_DATA_READ  0x49
+#define TM1650_CMD_DATA_READ  0x4f
 #define TM1650_CMD_ADDRESS  0x68
 
 


### PR DESCRIPTION
FD650B (clone of TM1650) need to read from 0x4f
this correspond to datasheet TM1650_V2.1  page 7
