### PR TITLE
Support user replacement of default font table

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -52,6 +52,10 @@ setDisplayDigit	KEYWORD2
 setDisplay	KEYWORD2
 clearDisplay	KEYWORD2
 setDisplayToString	KEYWORD2
+setDefaultAlphaFont	KEYWORD2
+getDefaultAlphaFont	KEYWORD2
+setDefaultNumberFont	KEYWORD2
+getDefaultNumberFont	KEYWORD2
 setLED	KEYWORD2
 setLEDs	KEYWORD2
 setRGBLED	KEYWORD2

--- a/src/TM1628.h
+++ b/src/TM1628.h
@@ -29,7 +29,7 @@ class TM1628 : public TM16xx
     virtual void clearDisplay();
 
     /** Set an Ascii character on a specific location (overloaded for 15-segment display) */
-    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = TM16XX_FONT_DEFAULT); // public method to allow calling from TM16xxDisplay
+    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = nullptr); // public method to allow calling from TM16xxDisplay
 
     // Set mapping array to be used when displaying segments
     // The array should contain _maxSegments bytes specifying the desired mapping

--- a/src/TM1640Anode.h
+++ b/src/TM1640Anode.h
@@ -21,7 +21,7 @@ class TM1640Anode : public TM1640
     TM1640Anode(byte dataPin, byte clockPin, byte numDigits=4, bool activateDisplay = true, byte intensity = 7);
 
     /** Set an Ascii character on a specific location (overloaded for 15-segment display) */
-		virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = TM16XX_FONT_DEFAULT); // public method to allow calling from TM16xxDisplay
+		virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = nullptr); // public method to allow calling from TM16xxDisplay
 
 		/** Set the segments at a specific position on or off */
 	  virtual void setSegments(byte segments, byte position);   // will duplicate G to G1/G2 in 15-segment

--- a/src/TM16xx.h
+++ b/src/TM16xx.h
@@ -59,10 +59,14 @@ class TM16xx
   public:
     /**
      * Instantiate a TM16xx module specifying data, clock and strobe pins (no strobe on some modules),
-     * maxDisplays - the maximum number of displays supported by the chip (as provided by derived chip specific class), 
-     * nDigitsUsed - the number of digits used to display numbers or text, 
+     * maxDisplays - the maximum number of displays supported by the chip (as provided by derived chip specific class),
+     * nDigitsUsed - the number of digits used to display numbers or text,
+     * defaultFont - the default font to use to interpret printable ASCII characters
      */
-    TM16xx(byte dataPin, byte clockPin, byte strobePin, byte maxDisplays, byte nDigitsUsed, bool activateDisplay=true, byte intensity=7);
+    TM16xx(byte dataPin, byte clockPin, byte strobePin, byte maxDisplays,
+           byte nDigitsUsed, bool activateDisplay = true, byte intensity = 7,
+           const byte defaultAlphaFont[95] = TM16XX_FONT_DEFAULT,
+           const byte defaultNumberFont[16] = TM16XX_NUMBER_FONT);
     /** DEPRECATED: activation, intensity (0-7) and display mode are no longer used by constructor. */
 
     /** Set the display (segments and LEDs) active or off and intensity (range from 0-7). */
@@ -80,6 +84,13 @@ class TM16xx
     /** Use explicit call in setup() or rely on implicit call by sendData(); calls setupDisplay() and clearDisplay() */
     virtual void begin(bool activateDisplay=true, byte intensity=7);
 
+    /** Set a new default alphanumeric font */
+    virtual void setDefaultAlphaFont(const byte font[95] = TM16XX_FONT_DEFAULT);
+    virtual byte *getDefaultAlphaFont() { return defaultFontAlpha; };
+    /** Set a new default numeric font */
+    virtual void setDefaultNumberFont(const byte font[16] = TM16XX_NUMBER_FONT);
+    virtual byte *getDefaultNumberFont() { return defaultFontNum; };
+
     /** Set segments of the display */
     virtual void setSegments(byte segments, byte position);
     virtual void setSegments16(uint16_t segments, byte position);   // some modules support more than 8 segments
@@ -89,7 +100,7 @@ class TM16xx
     //
 
     /** Set a single display at pos (starting at 0) to a digit (left to right) */
-    virtual void setDisplayDigit(byte digit, byte pos=0, bool dot=false, const byte numberFont[] = TM16XX_NUMBER_FONT);
+    virtual void setDisplayDigit(byte digit, byte pos=0, bool dot=false, const byte numberFont[] = nullptr);
 
     /** Set the display to a decimal number */
     virtual void setDisplayToDecNumber(int nNumber, byte bDots=0, bool fLeadingZeros=true);
@@ -100,12 +111,12 @@ class TM16xx
     virtual void setDisplay(const byte values[], byte size=8);
 
     /** Set the display to the string (defaults to built in 7-segment alphanumeric font) */
-    virtual void setDisplayToString(const char* string, const word dots=0, const byte pos=0, const byte font[] = TM16XX_FONT_DEFAULT);
+    virtual void setDisplayToString(const char *string, const word dots = 0, const byte pos = 0, const byte font[] = nullptr);
 
     virtual void sendChar(byte pos, byte data, bool dot); // made public to allow calling from TM16xxDisplay
     virtual void setNumDigits(byte numDigitsUsed);   // set number of digits used for alignment
     virtual byte getNumDigits(); // called by TM16xxDisplay to combine multiple modules
-    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = TM16XX_FONT_DEFAULT); // made public to allow calling from TM16xxDisplay
+    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = nullptr); // made public to allow calling from TM16xxDisplay
 
     // Key-scanning functions
     // Note: not all TM16xx chips support key-scanning and sizes are different per chip
@@ -144,6 +155,8 @@ auto min(T x, U y) -> decltype(x>y ? x : y)
 
     byte _maxDisplays=2;   // maximum number of digits (grids), chip-dependent
     byte _maxSegments=8;   // maximum number of segments per display, chip-dependent
+    byte *defaultFontAlpha;// default font table for alphanumerics (printable ACSII)
+    byte *defaultFontNum;  // default font table for (hexadecimal) digits
     bool flipped=false;    // sets the flipped state of the display;
     bool reversed=false;   // sets the reversed state of the display;
     bool fBeginDone=false; // for implicit begin checking;

--- a/src/TM16xxDisplay.cpp
+++ b/src/TM16xxDisplay.cpp
@@ -159,9 +159,10 @@ void TM16xxDisplay::setDisplayToError()
 
 void TM16xxDisplay::setDisplayToHexNumber(unsigned long number, byte dots, bool leadingZeros, const byte numberFont[])
 {
+  const byte *activeFont = numberFont ? numberFont : _pTM16xx->getDefaultNumberFont();
   for (int nPos = 0; nPos < _nNumDigits; nPos++) {
     if (number > 0 || leadingZeros || nPos==0) {
-      sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(numberFont + (number & 0xF)), (dots & (1 << nPos)) != 0);
+      sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(activeFont + (number & 0xF)), (dots & (1 << nPos)) != 0);
     } else {
       sendCharAt(_nNumDigits - nPos - 1, 0, (dots & (1 << nPos)) != 0);     // clearDisplayDigit
     }
@@ -174,9 +175,10 @@ void TM16xxDisplay::setDisplayToDecNumberAt(unsigned long number, byte dots, byt
   if (number > 99999999L) {
     setDisplayToError();    // original code: limit to 8 digit numbers
   } else {
+    const byte *activeFont = numberFont ? numberFont : _pTM16xx->getDefaultNumberFont();
     for (int nPos = 0; nPos < _nNumDigits - startingPos; nPos++) {
       if (number != 0 || nPos==0 || leadingZeros) {
-        sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(numberFont + (number  % 10)), (dots & (1 << nPos)) != 0);
+        sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(activeFont + (number  % 10)), (dots & (1 << nPos)) != 0);
       } else {
         sendCharAt(_nNumDigits - nPos - 1, 0, (dots & (1 << nPos)) != 0);     // clearDisplayDigit
       }
@@ -206,8 +208,9 @@ void TM16xxDisplay::setDisplayToSignedDecNumber(signed long number, byte dots, b
 
 void TM16xxDisplay::setDisplayToBinNumber(byte number, byte dots, const byte numberFont[])
 {
+  const byte *activeFont = numberFont ? numberFont : _pTM16xx->getDefaultNumberFont();
   for (int nPos = 0; nPos < _nNumDigits; nPos++) {
-    sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(numberFont + ((number & (1 << nPos)) == 0 ? 0 : 1)), (dots & (1 << nPos)) != 0);
+    sendCharAt(_nNumDigits - nPos - 1, pgm_read_byte_near(activeFont + ((number & (1 << nPos)) == 0 ? 0 : 1)), (dots & (1 << nPos)) != 0);
   }
 }
 

--- a/src/TM16xxDisplay.h
+++ b/src/TM16xxDisplay.h
@@ -40,18 +40,18 @@ class TM16xxDisplay : public Print
   virtual void setDisplayFlipped(bool flipped);
 
   // Set the display to the String (defaults to built in font)
-  virtual void setDisplayToString(const char* string, const word dots=0, const byte pos=0, const byte font[] = TM16XX_FONT_DEFAULT);
-  virtual void setDisplayToString(String string, const word dots=0, const byte pos=0, const byte font[] = TM16XX_FONT_DEFAULT);
+  virtual void setDisplayToString(const char* string, const word dots=0, const byte pos=0, const byte font[] = nullptr);
+  virtual void setDisplayToString(String string, const word dots=0, const byte pos=0, const byte font[] = nullptr);
   virtual void setDisplayToError();
 
   // Set the display to a unsigned hexadecimal number (with or without leading zeros)
-  void setDisplayToHexNumber(unsigned long number, byte dots, bool leadingZeros = true, const byte numberFont[] = TM16XX_NUMBER_FONT);
+  void setDisplayToHexNumber(unsigned long number, byte dots, bool leadingZeros = true, const byte numberFont[] = nullptr);
   // Set the display to a unsigned decimal number (with or without leading zeros)
-  void setDisplayToDecNumber(unsigned long number, byte dots, bool leadingZeros = true, const byte numberFont[] = TM16XX_NUMBER_FONT);
+  void setDisplayToDecNumber(unsigned long number, byte dots, bool leadingZeros = true, const byte numberFont[] = nullptr);
   // Set the display to a signed decimal number (with or without leading zeros)
-  void setDisplayToSignedDecNumber(signed long number, byte dots, bool leadingZeros = true, const byte numberFont[] = TM16XX_NUMBER_FONT);
+  void setDisplayToSignedDecNumber(signed long number, byte dots, bool leadingZeros = true, const byte numberFont[] = nullptr);
   // Set the display to a unsigned binary number
-  void setDisplayToBinNumber(byte number, byte dots, const byte numberFont[] = TM16XX_NUMBER_FONT);
+  void setDisplayToBinNumber(byte number, byte dots, const byte numberFont[] = nullptr);
 
   // support for the Print class
   void setCursor(int8_t nPos); 	// allows setting negative to support scrolled printing
@@ -76,6 +76,6 @@ class TM16xxDisplay : public Print
   void setDisplayToDecNumberAt(unsigned long number, byte dots, byte startingPos, bool leadingZeros, const byte numberFont[]);
   //TM16xx *TM16xxDisplay::findModuleByPos(const byte nPosFind);
   void sendCharAt(const byte nPos, byte btData, bool fDot);
-  void sendAsciiCharAt(const byte nPosCombi, char c, bool fDot, const byte font[] = TM16XX_FONT_DEFAULT);
+  void sendAsciiCharAt(const byte nPosCombi, char c, bool fDot, const byte font[] = nullptr);
 };
 #endif

--- a/src/TM16xxIC.h
+++ b/src/TM16xxIC.h
@@ -162,7 +162,7 @@ class TM16xxIC : public TM16xx
     /** use alphanumeric display (yes/no) with or without segment map */  
     virtual void setAlphaNumeric(bool fAlpha=true, const byte *pMap=NULL);    // const byte aMap[]
     /** Set an Ascii character on a specific location (overloaded for 15-segment display) */
-    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = TM16XX_FONT_DEFAULT); // public method to allow calling from TM16xxDisplay
+    virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = nullptr); // public method to allow calling from TM16xxDisplay
 
     /** Clear the display */
     virtual void clearDisplay();

--- a/src/TMHT16K33.h
+++ b/src/TMHT16K33.h
@@ -61,7 +61,7 @@ class TMHT16K33 : public TM16xx
 	  virtual void setSegments(byte segments, byte position);   // will duplicate G to G1/G2 in 15-segment
 	  virtual void setSegments16(uint16_t segments, byte position);   // some modules support more than 8 segments
     /** Set an Ascii character on a specific location (overloaded for 15-segment display) */
-		virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = TM16XX_FONT_DEFAULT); // public method to allow calling from TM16xxDisplay
+		virtual void sendAsciiChar(byte pos, char c, bool dot, const byte font[] = nullptr); // public method to allow calling from TM16xxDisplay
 
 	  // Set mapping array to be used when displaying segments
 	  // The array should contain _maxSegments bytes specifying the desired mapping


### PR DESCRIPTION
The methods that print characters and strings to the LED segments already support custom fonts to be used. However, unless all the optinal parameters are given at each call, the TM16xx display module will revert to the default font for subsequent display calls.

This commit allows the TM16xx display's default font to be replaced by a user-defined font table. The TM16xx class is able to setup it's default font at construction or the default font can be changed on the fly using the new setDefaultAlphaFont() and setDefaultNumberFont() methods. Internal member variables store pointers to the custom font tables in use, and the default font tables will be used if no custom font table is given.